### PR TITLE
Physical protection of OBD-II port

### DIFF
--- a/vehicleLangPublicInterfaces.mal
+++ b/vehicleLangPublicInterfaces.mal
@@ -40,7 +40,19 @@ category Communication {
 				->	interfacingNetworks.accessNetworkLayer
 
 		| connect
-				->	physicalAccess
+				->	connectNoProtection,
+					bypassConnectorProtection
+
+		& connectNoProtection
+				-> 	physicalAcces
+
+		# connectorAccessProtection
+				info: "Any type of physical entity blocking attackers from physically connecting to the OBD-II port. For example a protective plate covering the port or port being places where its diffcult to access."
+				->	connectNoProtection
+
+		| bypassConnectorProtection [ExponentialDistribution(10.0)]
+				info: "Remove of bypass objects blocking the OBD connector, for example ripping of protective plate or ganining access to driver cabin. Requires effort"
+				->	physicalAcces
 		}
 
 	asset ChargingPlugConnector

--- a/vehicleLangPublicInterfaces.mal
+++ b/vehicleLangPublicInterfaces.mal
@@ -40,19 +40,19 @@ category Communication {
 				->	interfacingNetworks.accessNetworkLayer
 
 		| connect
-				->	connectNoProtection,
-					bypassConnectorProtection
+				->	bypassConnectorProtection,
+				_connectNoProtection
 
-		& connectNoProtection
-				-> 	physicalAcces
+		| bypassConnectorProtection [ExponentialDistribution(20.0)]
+				info: "Remove of bypass objects blocking the OBD connector, for example ripping of protective plate or ganining access to driver cabin. Requires effort"
+				->	physicalAccess
+
+		& _connectNoProtection
+				-> 	physicalAccess
 
 		# connectorAccessProtection
 				info: "Any type of physical entity blocking attackers from physically connecting to the OBD-II port. For example a protective plate covering the port or port being places where its diffcult to access."
-				->	connectNoProtection
-
-		| bypassConnectorProtection [ExponentialDistribution(10.0)]
-				info: "Remove of bypass objects blocking the OBD connector, for example ripping of protective plate or ganining access to driver cabin. Requires effort"
-				->	physicalAcces
+				->	_connectNoProtection
 		}
 
 	asset ChargingPlugConnector

--- a/vehicleLangPublicInterfaces.mal
+++ b/vehicleLangPublicInterfaces.mal
@@ -44,14 +44,14 @@ category Communication {
 				_connectNoProtection
 
 		| bypassConnectorProtection [ExponentialDistribution(20.0)]
-				info: "Remove of bypass objects blocking the OBD connector, for example ripping of protective plate or ganining access to driver cabin. Requires effort"
+				info: "Remove or bypass objects blocking the OBD connector, for example ripping of protective plate or ganining access to driver cabin. Requires effort"
 				->	physicalAccess
 
 		& _connectNoProtection
 				-> 	physicalAccess
 
 		# connectorAccessProtection
-				info: "Any type of physical entity blocking attackers from physically connecting to the OBD-II port. For example a protective plate covering the port or port being places where its diffcult to access."
+				info: "Any type of physical entity blocking attackers from physically connecting to the OBD-II port. For example a protective plate covering the port or port being placed where it's difficult to access."
 				->	_connectNoProtection
 		}
 

--- a/vehicleLangPublicInterfaces.mal
+++ b/vehicleLangPublicInterfaces.mal
@@ -40,10 +40,10 @@ category Communication {
 				->	interfacingNetworks.accessNetworkLayer
 
 		| connect
-				->	bypassConnectorProtection,
+				-> bypassConnectorProtection,
 				_connectNoProtection
 
-		| bypassConnectorProtection [ExponentialDistribution(20.0)]
+		| bypassConnectorProtection [ExponentialDistribution(20.0)]
 				info: "Remove of bypass objects blocking the OBD connector, for example ripping of protective plate or ganining access to driver cabin. Requires effort"
 				->	physicalAccess
 


### PR DESCRIPTION
A defense which prevents the attacker from immediately being able to connect to the OBD-II port. Was suggested by an employee at a vehicle manufacturer. 

**Note:** The ttc value for `bypassConnectorProtection` is bogus. 