### PR TITLE
Add script for building with the foreseeti backend

### DIFF
--- a/build-foreseeti.sh
+++ b/build-foreseeti.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+mvn clean
+mvn -f foreseetipom.xml package -Dmaven.test.skip


### PR DESCRIPTION
Makes it easier to compile for the foreseeti backend without having to remember the maven command every time.